### PR TITLE
upgraded node-addon-api

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
     "electron-rebuild": "^1.8.2"
   },
   "dependencies": {
-    "node-addon-api": "^1.5.0"
+    "node-addon-api": "^2.0.0"
   }
 }


### PR DESCRIPTION
Somehow there are random/strange issues in node-addon-api 1.7:
- trigger purchaseProduct()
- close the Microsoft window via X
- notice that the callback isn't triggers until the whole (Electron) App is closed (the callback is fired when the process/thread is shutting down) -> way to late to handle this cases

With version 2.0 it looks way better