### PR TITLE
Adds ReportConsumableFulfillmentAsync function

### DIFF
--- a/src/ReportConsumableFulfillmentAsyncWorker.cpp
+++ b/src/ReportConsumableFulfillmentAsyncWorker.cpp
@@ -1,0 +1,40 @@
+#include "ReportConsumableFulfillmentAsyncWorker.h"
+#include <Windows.h>
+#include <iostream>
+#include <napi.h>
+#include <string>
+
+ReportConsumableFulfillmentAsyncWorker::ReportConsumableFulfillmentAsyncWorker(
+    const Napi::Function &callback, std::string addOnStoreId, int quantity, winrt::guid trackingId, WindowsStoreImpl *pImpl)
+    : Napi::AsyncWorker(callback), m_addonstoreid(addOnStoreId), m_quantity(quantity), m_trackingid(trackingId), m_pImpl(pImpl),
+      m_result(NULL, NULL) {}
+
+void ReportConsumableFulfillmentAsyncWorker::Execute() {
+  m_result = m_pImpl->ReportConsumableFulfillmentAsync(m_addonstoreid, m_quantity, m_trackingid);
+}
+
+void ReportConsumableFulfillmentAsyncWorker::OnOK() {
+  Napi::Env env = Env();
+  Napi::Object obj = Napi::Object::New(env);
+  if (m_result.extended_error != NULL) {
+    obj.Set("extendedError", m_result.extended_error);
+  }
+  if (m_result.status != NULL) {
+    obj.Set("status", m_result.status);
+  }
+  std::string returnTrackingId;
+  std::array<char,38> convertGuid;
+  snprintf(convertGuid.data(), convertGuid.size(), "%08X-%04hX-%04hX-%02X%02X-%02X%02X%02X%02X%02X%02X", m_trackingid.Data1, m_trackingid.Data2, m_trackingid.Data3, m_trackingid.Data4[0], m_trackingid.Data4[1], m_trackingid.Data4[2], m_trackingid.Data4[3], m_trackingid.Data4[4], m_trackingid.Data4[5], m_trackingid.Data4[6], m_trackingid.Data4[7]);
+  returnTrackingId = convertGuid.data();
+  obj.Set("TrackingId", returnTrackingId);
+  Callback().MakeCallback(Receiver().Value(), {
+                                                  env.Null(), // error first callback
+                                                  obj         // this is apparently the value sent back to the callback
+                                              });
+}
+
+void ReportConsumableFulfillmentAsyncWorker::OnError(const Napi::Error &e) {
+  Napi::Env env = Env();
+
+  Callback().MakeCallback(Receiver().Value(), {e.Value(), env.Undefined()});
+}

--- a/src/ReportConsumableFulfillmentAsyncWorker.h
+++ b/src/ReportConsumableFulfillmentAsyncWorker.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "WindowsStoreImpl.h"
+#include <napi.h>
+#include <string>
+
+class ReportConsumableFulfillmentAsyncWorker : public Napi::AsyncWorker {
+public:
+  ReportConsumableFulfillmentAsyncWorker(const Napi::Function &callback, std::string addOnStoreId,
+                             int quantity, winrt::guid trackingId,
+                             WindowsStoreImpl *pImpl);
+
+protected:
+  virtual void Execute() override;
+  virtual void OnOK() override;
+  virtual void OnError(const Napi::Error &e) override;
+
+private:
+  WindowsStoreImpl *m_pImpl;
+  std::string m_addonstoreid;
+  int m_quantity;
+  winrt::guid m_trackingid;
+  WindowsStoreImpl::StoreConsumableStatus m_result;
+};

--- a/src/StoreContext.h
+++ b/src/StoreContext.h
@@ -15,6 +15,7 @@ private:
   void GetAssociatedStoreProductsAsync(const Napi::CallbackInfo &info);
   void GetCustomerPurchaseIdAsync(const Napi::CallbackInfo &info);
   void RequestPurchaseAsync(const Napi::CallbackInfo &info);
+  void ReportConsumableFulfillmentAsync(const Napi::CallbackInfo &info);
   void GetAppLicenseAsync(const Napi::CallbackInfo &info);
 
   Napi::Value Initialize(const Napi::CallbackInfo &info);

--- a/src/WindowsStoreImpl.cpp
+++ b/src/WindowsStoreImpl.cpp
@@ -198,3 +198,20 @@ WindowsStoreImpl::RequestPurchaseAsync(std::string storeId, StorePurchasePropert
     return WindowsStoreImpl::StorePurchaseResult(result.ExtendedError(), NULL);
   }
 }
+
+WindowsStoreImpl::StoreConsumableStatus
+WindowsStoreImpl::ReportConsumableFulfillmentAsync(std::string addOnStoreId, int quantity, winrt::guid trackingId) {
+  StoreContext context = StoreContext::GetDefault();
+  auto initWindow = context.try_as<IInitializeWithWindow>();
+  if (initWindow != nullptr) {
+    HRESULT hr = initWindow->Initialize(m_hwnd);
+  }
+
+  auto result = context.ReportConsumableFulfillmentAsync(to_hstring(addOnStoreId), quantity, trackingId).get();
+
+  if (result.ExtendedError() == S_OK) {
+    return WindowsStoreImpl::StoreConsumableStatus(NULL, static_cast<int>(result.Status()));
+  } else {
+    return WindowsStoreImpl::StoreConsumableStatus(result.ExtendedError(), NULL);
+  }
+}

--- a/src/WindowsStoreImpl.h
+++ b/src/WindowsStoreImpl.h
@@ -21,6 +21,12 @@ public:
     StorePurchaseResult(int extendedError, int stat) : extended_error(extendedError), status(stat) {}
   };
 
+  struct StoreConsumableStatus {
+    int extended_error;
+    int status;
+    StoreConsumableStatus(int extendedError, int stat) : extended_error(extendedError), status(stat) {}
+  };
+
   struct StoreProduct {
     std::string in_app_purchase_token;
     StoreProduct(std::string inAppPurchaseToken) : in_app_purchase_token(inAppPurchaseToken) {}
@@ -45,6 +51,7 @@ public:
   StorePurchaseResult
   RequestPurchaseAsync(std::string storeId,
                        winrt::Windows::Services::Store::StorePurchaseProperties &purchaseProperties);
+  StoreConsumableStatus ReportConsumableFulfillmentAsync(std::string addOnStoreId, int quantity, winrt::guid trackingId);
 
 private:
   bool GetIsMicrosoftAccrued(AttributionScope scope);


### PR DESCRIPTION
This adds the ReportConsumableFulfillmentAsync function to the IAP-bridge.  This is used for ManagedConsumable and UnmanagedConsumable AddOns, which can only be purchased once unless the app reports them fulfilled using this function.